### PR TITLE
added new federal layers with empty geom

### DIFF
--- a/crdppf/util/pdf_classes.py
+++ b/crdppf/util/pdf_classes.py
@@ -579,10 +579,10 @@ class Extract(FPDF):
         else:
             if str(topic.topicid) in self.appconfig.emptytopics:
                 self.topiclist[str(topic.topicid)]['layers'] = None
-                self.topiclist[str(topic.topicid)]['categorie']=1
+                self.topiclist[str(topic.topicid)]['categorie'] = 1
             else:
                 self.topiclist[str(topic.topicid)]['layers'] = None
-                self.topiclist[str(topic.topicid)]['categorie']=0
+                self.topiclist[str(topic.topicid)]['categorie'] = 0
 
         # if legal bases are defined for a topic the attributes are compiled in a list
         if topic.legalbases:


### PR DESCRIPTION
@kalbermattenm: please give it a quick look.

remarks:
This PR slightly modifies the way that topics certified with 'no data' content are listed in the pdf. Thus you have to add an entry 'emptytopics' in the config_pdf.yaml.in (app_config section) listing the topics of this kind:
 emptytopics: ['87','88','96','97','104'] - or whatever topics with no geometry you have.
