### PR TITLE
Alllegalsfix

### DIFF
--- a/crdppf/__init__.py
+++ b/crdppf/__init__.py
@@ -71,7 +71,6 @@ def includeme(config):
     config.add_route('get_translations_list', 'get_translations_list')
     config.add_route('get_interface_config', 'get_interface_config')
     config.add_route('get_baselayers_config', 'get_baselayers_config')
-    #config.add_route('get_basemap_sld', 'get_basemap_sld')
     config.add_route('test', 'test')
     config.add_route('formulaire_reglements', 'formulaire_reglements')
     config.add_route('getTownList', 'getTownList')
@@ -79,7 +78,6 @@ def includeme(config):
     config.add_route('createNewDocEntry', 'createNewDocEntry')
     config.add_route('getDocumentReferences', 'getDocumentReferences')
     config.add_route('getLegalDocuments', 'getLegalDocuments')
-    config.add_route('getLegalbases', 'getLegalbases')
     config.add_route('map', 'map')
     config.add_route('configpanel', 'configpanel')
     

--- a/crdppf/models.py
+++ b/crdppf/models.py
@@ -38,20 +38,16 @@ class AppConfig(Base):
     
 # START models used for static extraction and general models
 class Topics(Base):
-    __tablename__ = 'topic'
+    __tablename__ = 'topics'
     __table_args__ = {'schema': db_config['schema'], 'autoload': True}
     layers = relationship("Layers", backref=backref("layers"),lazy="joined")
     authorityfk = Column(Integer, ForeignKey('crdppf.authority.authorityid'))
     authority = relationship("Authority", backref=backref("authority"),lazy="joined")
-    legalbases = relationship("LegalBases", backref=backref("legalbases"),lazy="joined")
-    legalprovisions = relationship("LegalProvisions", backref=backref("legalprovisions"),lazy="joined")
-    temporaryprovisions = relationship("TemporaryProvisions", backref=backref("temporaryprovisions"),lazy="joined")
-    references = relationship("References", backref=backref("references"),lazy="joined")
     
 class Layers(Base):
     __tablename__ = 'layers'
     __table_args__ = {'schema': db_config['schema'], 'autoload': True}
-    topicfk = Column(String, ForeignKey('crdppf.topic.topicid'))
+    topicfk = Column(String, ForeignKey('crdppf.topics.topicid'))
     topic = relationship("Topics", backref=backref("topic"),lazy="joined")
 
 class Documents(Base):
@@ -88,26 +84,6 @@ class DocumentType(Base):
 class Authority(Base):
     __tablename__ = 'authority'
     __table_args__ = {'schema': db_config['schema'], 'autoload': True}
-
-class LegalBases(Base):
-    __tablename__ = 'legalbases'
-    __table_args__ = {'schema': db_config['schema'], 'autoload': True}
-    topicfk = Column(String(10), ForeignKey('crdppf.topic.topicid'))
-
-class LegalProvisions(Base):
-    __tablename__ = 'legalprovisions'
-    __table_args__ = {'schema': db_config['schema'], 'autoload': True}
-    topicfk = Column(String(10), ForeignKey('crdppf.topic.topicid')) 
-
-class TemporaryProvisions(Base):
-    __tablename__ = 'temporaryprovisions'
-    __table_args__ = {'schema': db_config['schema'], 'autoload': True}
-    topicfk = Column(String(10), ForeignKey('crdppf.topic.topicid'))
-
-class References(Base):
-    __tablename__ = 'references'
-    __table_args__ = {'schema': db_config['schema'], 'autoload': True}
-    topicfk = Column(String(10), ForeignKey('crdppf.topic.topicid'))
 
 class PaperFormats(Base):
     __tablename__ = 'paperformats'

--- a/crdppf/static/js/Crdppf/featurePanel.js
+++ b/crdppf/static/js/Crdppf/featurePanel.js
@@ -239,7 +239,7 @@ Crdppf.FeaturePanel.prototype = {
         var parcelId = property.attributes.idemai;
         // Update parameters for legal documents filtering
         Crdppf.filterlist.cadastrenb = parseInt(parcelId.split('_',1)[0]);
-        Crdppf.filterlist.municipalitynb = Number(property.attributes.nufeco);
+        Crdppf.filterlist.chmunicipalitynb = Number(property.attributes.nufeco);
         Crdppf.docfilters(Crdppf.filterlist);
         
         // If no result, display no results message

--- a/crdppf/static/js/Crdppf/featurePanel.js
+++ b/crdppf/static/js/Crdppf/featurePanel.js
@@ -238,7 +238,7 @@ Crdppf.FeaturePanel.prototype = {
 
         var parcelId = property.attributes.idemai;
         // Update parameters for legal documents filtering
-        Crdppf.filterlist.cadastrenb = parseInt(parcelId.split('_',1)[0]);
+        Crdppf.filterlist.cadastrenb = parseInt(parcelId.split('_', 1)[0]);
         Crdppf.filterlist.chmunicipalitynb = Number(property.attributes.nufeco);
         Crdppf.docfilters(Crdppf.filterlist);
         

--- a/crdppf/static/js/Crdppf/featurePanel.js
+++ b/crdppf/static/js/Crdppf/featurePanel.js
@@ -74,7 +74,7 @@ Crdppf.FeaturePanel.prototype = {
     PropertySelection: function(features, labels) {
         
         var propertySelectionWindow;
-        
+
         if (features.length > 1) {
             var properties = [];
             for (var i = 0; i < features.length; i++){
@@ -82,7 +82,8 @@ Crdppf.FeaturePanel.prototype = {
                     i,
                     features[i].data.typimm+': '+features[i].data.nummai+' '+features[i].data.cadastre,
                     features[i].data.idemai,
-                    features[i].data.source
+                    features[i].data.source,
+                    features[i].data.nufeco
                 ];
             }
 
@@ -236,9 +237,10 @@ Crdppf.FeaturePanel.prototype = {
         Crdppf.Map.selectLayer.addFeatures([property]);
 
         var parcelId = property.attributes.idemai;
-        
-        // Update legal documents
-        Crdppf.docfilters({'cadastrenb': parseInt(parcelId.split('_',1)[0])});
+        // Update parameters for legal documents filtering
+        Crdppf.filterlist.cadastrenb = parseInt(parcelId.split('_',1)[0]);
+        Crdppf.filterlist.municipalitynb = Number(property.attributes.nufeco);
+        Crdppf.docfilters(Crdppf.filterlist);
         
         // If no result, display no results message
         if (Crdppf.LayerTreePanel.overlaysList.length === 0) {

--- a/crdppf/static/js/Crdppf/layerTree.js
+++ b/crdppf/static/js/Crdppf/layerTree.js
@@ -50,6 +50,7 @@ Crdppf.LayerTreePanel.prototype = {
             leaf: true,
             listeners: {
                 'checkchange': function(node,checked){
+                    Crdppf.filterlist.topic = [];
                     if(checked){
                         layerTree.expandAll();
                         for (var n=1; n < rootLayerTree.childNodes.length; n++){
@@ -85,30 +86,31 @@ Crdppf.LayerTreePanel.prototype = {
                 checked: false,
                 listeners: {
                     'checkchange': function(node, checked){
-                        var filter = {};
                         if (checked){
-                            filter[node.id] = checked;
-                            Crdppf.docfilters({'topicfk':filter});
                             node.expand();
                             Crdppf.updateLayers = false;
                             for (var k=0; k < node.childNodes.length; k++){
                                 node.childNodes[k].getUI().toggleCheck(true);
                                 if (Crdppf.LayerTreePanel.overlaysList.indexOf(node.childNodes[k].id) == -1) {
                                     Crdppf.LayerTreePanel.overlaysList.push(node.childNodes[k].id);
+                                    Crdppf.filterlist.layers.push(node.childNodes[k].id);
                                 }
                             }
+                            Crdppf.filterlist.topic.push(node.id);
+                            Crdppf.docfilters(Crdppf.filterlist);
                             Crdppf.updateLayers = true;
                             Crdppf.Map.setOverlays();
                             Crdppf.FeaturePanel.setInfoControl();
-                        } else {
-                            filter[node.id] = checked;
-                            Crdppf.docfilters({'topicfk':filter});                
+                        } else {         
                             node.collapse();
                             Crdppf.updateLayers = false;
                             for (var k=0; k < node.childNodes.length; k++){
                                 node.childNodes[k].getUI().toggleCheck(false);
                                 Crdppf.LayerTreePanel.overlaysList.remove(node.childNodes[k].id);
+                                Crdppf.filterlist.layers.remove(node.childNodes[k].id);
                             }
+                            Crdppf.filterlist.topic.remove(node.id);
+                            Crdppf.docfilters(Crdppf.filterlist);
                             Crdppf.updateLayers = true;
                             Crdppf.Map.setOverlays();
                             Crdppf.FeaturePanel.setInfoControl();
@@ -131,12 +133,14 @@ Crdppf.LayerTreePanel.prototype = {
                                     if(Crdppf.updateLayers) {
                                         if (Crdppf.LayerTreePanel.overlaysList.indexOf(node.id) == -1) {
                                             Crdppf.LayerTreePanel.overlaysList.push(node.id);
+                                            Crdppf.filterlist.layers.push(node.id);
                                         }
                                         Crdppf.Map.setOverlays();
                                         Crdppf.FeaturePanel.setInfoControl();
                                     }
                                 } else {
                                     Crdppf.LayerTreePanel.overlaysList.remove(node.id);
+                                    Crdppf.filterlist.layers.remove(node.id);
                                     if(Crdppf.updateLayers) {
                                         Crdppf.Map.setOverlays();
                                     }

--- a/crdppf/static/js/Crdppf/legalDocuments.js
+++ b/crdppf/static/js/Crdppf/legalDocuments.js
@@ -36,26 +36,15 @@ Crdppf.docfilters = function(filter) {
                     } else {
                         if (record.get('cadastrenb') === Crdppf.filterlist.cadastrenb || record.get('cadastrenb') === null) {
                             return record;
-                        } else {
-                            return record;
-                        }
+                        } 
                     }
                 }
             }
         } else {
-            if (record.get('chmunicipalitynb') === Crdppf.filterlist.chmunicipalitynb || record.get('chmunicipalitynb') === null) {
-                if (record.get('cadastrenb') === Crdppf.filterlist.cadastrenb || record.get('cadastrenb') === null) {
-                    return record;
-                }
-            } else {
-                if (record.get('cadastrenb') === Crdppf.filterlist.cadastrenb || record.get('cadastrenb') === null) {
-                    return record;
-                } else {
-                    return record;
-                }
-            }
+            return record;
         }
     });
+    
     return Crdppf.filterlist;
 };
 
@@ -86,7 +75,7 @@ Crdppf.legalDocuments = function() {
             },
             // definition of the column model
             [
-            {name: 'docid'},
+            {name: 'documentid'},
             {name: 'doctype'},
             {name: 'lang'},
             {name: 'state'},

--- a/crdppf/static/js/Crdppf/legalDocuments.js
+++ b/crdppf/static/js/Crdppf/legalDocuments.js
@@ -131,7 +131,7 @@ Crdppf.legalDocuments.createView = function(labels) {
                         '<tpl if="this.isLegalbase(doctype) &amp;&amp; this.isFederal(state, municipalityname)">',
                             '<tpl for=".">',
                                 '<div style="font-size:10pt;padding:5px 15px;background-color:{[xindex % 2 === 0 ? "#FFFFFF" : "#F5F5F5"]}">',
-                                    '<h3 class="doctitle"><a href="#" onClick="window.open(\'{remoteurl}\');" target="_blank">{[xcount]} {officialnb}</a> - {officialtitle} du {publicationdate:date("d.m.Y")}</h3>',
+                                    '<h3 class="doctitle"><a href="#" onClick="window.open(\'{remoteurl}\');" target="_blank">{officialnb}</a> - {officialtitle} du {publicationdate:date("d.m.Y")}</h3>',
                                     '<p class="docurl"><b>URL:</b> <a href="#" onClick="window.open(\'{remoteurl}\');" target="_blank">{remoteurl}</a></p>',
                                 '</div>',
                             '</tpl>',

--- a/crdppf/static/js/Crdppf/legalDocuments.js
+++ b/crdppf/static/js/Crdppf/legalDocuments.js
@@ -1,6 +1,6 @@
 Ext.namespace('Crdppf');
 
-Crdppf.filterlist = {'topic' : [], 'layers': [], 'municipalitynb': 0, 'cadastrenb': 0, 'objectids': []};
+Crdppf.filterlist = {'topic' : [], 'layers': [], 'chmunicipalitynb': null, 'cadastrenb': null, 'objectids': []};
 
 Crdppf.docfilters = function(filter) {
     // little helper function to check for the existence of an value in an array
@@ -29,40 +29,32 @@ Crdppf.docfilters = function(filter) {
             for (var j = 0; j < Crdppf.filterlist.topic.length; j++){
             // if the topicid is in the filterlist show the corresponding documents
                 if (record.get('origins').indexOf(Crdppf.filterlist.topic[j]) > -1) {
-                    if (record.get('municipalitynb') === Crdppf.filterlist.municipalitynb || record.get('municipalitynb') === null) {
+                    if (record.get('chmunicipalitynb') === Crdppf.filterlist.chmunicipalitynb || record.get('chmunicipalitynb') === null) {
                         if (record.get('cadastrenb') === Crdppf.filterlist.cadastrenb || record.get('cadastrenb') === null) {
                             return record;
                         }
-                        console.log(record.get('municipalitynb'));
+                    } else {
+                        if (record.get('cadastrenb') === Crdppf.filterlist.cadastrenb || record.get('cadastrenb') === null) {
+                            return record;
+                        } else {
+                            return record;
+                        }
                     }
                 }
             }
         } else {
-            if (record.get('cadastrenb') === Crdppf.filterlist.cadastrenb || record.get('cadastrenb') === null) {
-                return record;
+            if (record.get('chmunicipalitynb') === Crdppf.filterlist.chmunicipalitynb || record.get('chmunicipalitynb') === null) {
+                if (record.get('cadastrenb') === Crdppf.filterlist.cadastrenb || record.get('cadastrenb') === null) {
+                    return record;
+                }
+            } else {
+                if (record.get('cadastrenb') === Crdppf.filterlist.cadastrenb || record.get('cadastrenb') === null) {
+                    return record;
+                } else {
+                    return record;
+                }
             }
         }
-        //~ if (Crdppf.filterlist.cadastrenb > 0){
-            //~ if (record.get('cadastrenb') === Crdppf.filterlist.cadastrenb || record.get('cadastrenb') === 0) {
-                //~ if (Crdppf.filterlist.topic.length > 0) {
-                    //~ for (var i = 0; i < Crdppf.filterlist.topic.length; i++){
-                    //~ // if the topicid is in the filterlist show the corresponding documents
-                        //~ if (record.get('origins').indexOf(Crdppf.filterlist.topic[i]) > -1) {
-                            //~ return record;
-                        //~ }
-                    //~ }
-                //~ } else {
-                    //~ return record;
-                //~ }
-            //~ }
-        //~ } else {
-            //~ for (var j = 0; j < Crdppf.filterlist.topic.length; j++){
-            //~ // if the topicid is in the filterlist show the corresponding documents
-                //~ if (record.get('origins').indexOf(Crdppf.filterlist.topic[j]) > -1) {
-                    //~ return record;
-                //~ }
-            //~ }
-        //~ }
     });
     return Crdppf.filterlist;
 };

--- a/crdppf/static/js/Crdppf/legalDocuments.js
+++ b/crdppf/static/js/Crdppf/legalDocuments.js
@@ -7,7 +7,7 @@ Crdppf.docfilters = function(filter) {
     function isInArray(value, array) {
         return array.indexOf(value) > -1;
     }
-    
+
     if ('objectids' in filter) {
         if (filter.objectids.length > 0) {
             for (var i = 0; i < filter.objectids.length; i++) {
@@ -118,7 +118,7 @@ Crdppf.legalDocuments = function() {
 Crdppf.legalDocuments.createView = function(labels) {
 
     var legalDocumentsStore = null;
-    
+
     if (Crdppf.legalDocuments.store.getTotalCount()> 0) {
         // Parse the legal documents and apply the corresponding template
         var templates = new Ext.XTemplate(

--- a/crdppf/static/js/Crdppf/main.js
+++ b/crdppf/static/js/Crdppf/main.js
@@ -26,7 +26,7 @@ Ext.onReady(function() {
     var sync = 0;
 
     var synchronize = function(sync) {
-        if (sync == 1 && Crdppf.disclaimer === true) {
+        if (sync === 1 && Crdppf.disclaimer === true) {
             Ext.MessageBox.buttonText.yes = Crdppf.labels.disclaimerAcceptance;
             Ext.MessageBox.buttonText.no = Crdppf.labels.diclaimerRefusal;
             var dlg = Ext.MessageBox.getDialog();
@@ -34,7 +34,6 @@ Ext.onReady(function() {
             for (var i = 0; i < buttons.length; i++){
                  buttons[i].addClass('msgButtonStyle'); 
             }
-
             Ext.Msg.show({
                title: Crdppf.labels.disclaimerWindowTitle,
                msg: Crdppf.labels.disclaimerMsg,
@@ -43,14 +42,14 @@ Ext.onReady(function() {
                animEl: 'elId',
                icon: Ext.MessageBox.WARNING
             });
-        } else if (sync == 1) {
+        } else if (sync === 1) {
             redirectAfterDisclaimer('yes');
         }
     };
 
-    var triggerFunction = function(counter) {
-        if (counter == 2) {
-            synchronize();
+    Crdppf.triggerFunction = function(counter) {
+        if (counter == 3) {
+            synchronize(sync); 
         }
     };
 
@@ -82,7 +81,7 @@ Ext.onReady(function() {
                 OpenLayers.Util.extend(OpenLayers.Lang.fr, Crdppf.labels);
             }
             Crdppf.loadingCounter += 1;
-            triggerFunction(Crdppf.loadingCounter);            
+            Crdppf.triggerFunction(Crdppf.loadingCounter);            
         },
         method: 'POST',
         failure: function () {
@@ -96,7 +95,8 @@ Ext.onReady(function() {
         success: function(response) {
             Crdppf.layerList = Ext.decode(response.responseText);
             sync += 1;
-            synchronize(sync);        
+            Crdppf.loadingCounter += 1;
+            Crdppf.triggerFunction(Crdppf.loadingCounter);    
         },
         method: 'POST',
         failure: function () {
@@ -168,7 +168,8 @@ Crdppf.init_main = function(lang) {
         listeners:{
             click: function (){
                 Crdppf.FeaturePanel.disableInfoControl();
-                Crdppf.docfilters({'cadastrenb':0});
+                Crdppf.filterlist.cadastrenb = 0;
+                Crdppf.filterlist.municipalitynb = 0;
                 for (var i = Crdppf.filterlist.objectids.length; i > 0; i--){
                     Crdppf.docfilters({'objectids':[Crdppf.filterlist.objectids[i-1]]});
                 }

--- a/crdppf/static/js/Crdppf/map.js
+++ b/crdppf/static/js/Crdppf/map.js
@@ -70,15 +70,6 @@ Crdppf.Map.prototype = {
             }
         });
 
-        control.events.register("beforefeatureselected", this, function(e) {
-            Crdppf.Map.selectLayer.removeAllFeatures();
-            Crdppf.currentProperty = null;
-            var propertySelectionWindow = Ext.getCmp('propertySelectionWindow');
-            if (propertySelectionWindow) {
-                propertySelectionWindow.destroy();
-            }
-        });
-
         // define actions on feature selection
         control.events.register("featuresselected", this, function(e) {
             // if there is more than one feature, we present the user with a selection window

--- a/crdppf/util/pdf_classes.py
+++ b/crdppf/util/pdf_classes.py
@@ -761,17 +761,17 @@ class Extract(FPDF):
         self.legalprovisionslist[str(topicid)]=[]
         for provision in legalprovisions:
             self.legalprovisionslist[str(topicid)].append({
-                'officialtitle':provision[u'officialtitle'],
-                'title':provision['title'],
-                'abreviation':provision['abbreviation'],
-                'officialnb':provision['officialnb'],
+                'officialtitle': provision[u'officialtitle'],
+                'title': provision['title'],
+                'abreviation': provision['abbreviation'],
+                'officialnb': provision['officialnb'],
                 'legalprovisionurl':provision['remoteurl'],
-                'canton':provision['state'],
-                'commune':provision['municipalityname'],
-                'legalstate':provision['legalstate'],
-                'publishedsince':provision['publicationdate'],
-                'sanctiondate':provision['sanctiondate'],
-                'no_page':'A'+str(len(self.appendix_entries))
+                'canton': provision['state'],
+                'commune': provision['municipalityname'],
+                'legalstate': provision['legalstate'],
+                'publishedsince': provision['publicationdate'],
+                'sanctiondate': provision['sanctiondate'],
+                'no_page': 'A'+str(len(self.appendix_entries))
                 #'metadata':provision.metadata
                 })
         self.topiclist[str(topicid)]['legalprovision'] = self.legalprovisionslist[str(topicid)]
@@ -782,17 +782,17 @@ class Extract(FPDF):
         self.referenceslist[str(topicid)]=[]
         for reference in references:
             self.referenceslist[str(topicid)].append({
-                'officialtitle':reference['officialtitle'],
-                'title':reference['title'],
-                'abreviation':reference['abbreviation'],
-                'officialnb':reference['officialnb'],
-                'legalprovisionurl':reference['remoteurl'],
-                'canton':reference['state'],
-                'commune':reference['municipalityname'],
-                'legalstate':reference['legalstate'],
-                'publishedsince':reference['publicationdate'],
-               'sanctiondate':reference['sanctiondate'],
-                'no_page':'A'+str(len(self.appendix_entries))
+                'officialtitle': reference['officialtitle'],
+                'title': reference['title'],
+                'abreviation': reference['abbreviation'],
+                'officialnb': reference['officialnb'],
+                'legalprovisionurl': reference['remoteurl'],
+                'canton': reference['state'],
+                'commune': reference['municipalityname'],
+                'legalstate': reference['legalstate'],
+                'publishedsince': reference['publicationdate'],
+                'sanctiondate': reference['sanctiondate'],
+                'no_page': 'A'+str(len(self.appendix_entries))
                 #'metadata':legalprovision.metadata
                 })
         self.topiclist[str(topicid)]['references'] = self.referenceslist[str(topicid)]
@@ -1372,7 +1372,7 @@ class Extract(FPDF):
         self.cell(15, 6, self.translations['pagelabel'], 0, 0, 'L')
         self.cell(135, 6, self.translations['appendicestitlelabel'], 0, 1, 'L')
         
-        index = 1
+        index =+ 1
         if len(self.appendix_entries) > 0:
             for appendix in self.appendix_entries:
                 self.set_font(*self.pdfconfig.textstyles['tocbold'])
@@ -1385,7 +1385,7 @@ class Extract(FPDF):
                     self.set_text_color(*self.pdfconfig.urlcolor)
                     self.multi_cell(0, 5, str(appendix['url']))
                     self.set_text_color(*self.pdfconfig.defaultcolor)
-                index = index+1
+                index =+ 1
         else:
             self.multi_cell(0, 5, self.translations['nodocumenttext'])
 

--- a/crdppf/util/pdf_classes.py
+++ b/crdppf/util/pdf_classes.py
@@ -1402,7 +1402,7 @@ class Extract(FPDF):
                     self.set_text_color(*self.pdfconfig.urlcolor)
                     self.multi_cell(0, 5, str(appendix['url']))
                     self.set_text_color(*self.pdfconfig.defaultcolor)
-                index =+ 1
+                index += 1
         else:
             self.multi_cell(0, 5, self.translations['nodocumenttext'])
 

--- a/crdppf/util/pdf_classes.py
+++ b/crdppf/util/pdf_classes.py
@@ -1373,19 +1373,21 @@ class Extract(FPDF):
         self.cell(135, 6, self.translations['appendicestitlelabel'], 0, 1, 'L')
         
         index = 1
-        for appendix in self.appendix_entries:
-            self.set_font(*self.pdfconfig.textstyles['tocbold'])
-            self.appendix_links.append(self.add_link())
-            self.cell(15, 6, str('A'+str(index)), 0, 0, 'L')
-            self.multi_cell(0, 6, appendix['title'], 0, 'L')
-            if self.reportInfo['type'] == 'reduced' or self.reportInfo['type'] == 'reducedcertified':
-                self.set_x(40)
-                self.set_font(*self.pdfconfig.textstyles['tocurl'])
-                self.set_text_color(*self.pdfconfig.urlcolor)
-                self.multi_cell(0, 5, str(appendix['url']))
-                self.set_text_color(*self.pdfconfig.defaultcolor)
-
-            index = index+1
+        if len(self.appendix_entries) > 0:
+            for appendix in self.appendix_entries:
+                self.set_font(*self.pdfconfig.textstyles['tocbold'])
+                self.appendix_links.append(self.add_link())
+                self.cell(15, 6, str('A'+str(index)), 0, 0, 'L')
+                self.multi_cell(0, 6, appendix['title'], 0, 'L')
+                if self.reportInfo['type'] == 'reduced' or self.reportInfo['type'] == 'reducedcertified':
+                    self.set_x(40)
+                    self.set_font(*self.pdfconfig.textstyles['tocurl'])
+                    self.set_text_color(*self.pdfconfig.urlcolor)
+                    self.multi_cell(0, 5, str(appendix['url']))
+                    self.set_text_color(*self.pdfconfig.defaultcolor)
+                index = index+1
+        else:
+            self.multi_cell(0, 5, self.translations['nodocumenttext'])
 
     def clean_up_temp_files(self):
         """ Removes the temporary files needed to create an extract:

--- a/crdppf/util/pdf_classes.py
+++ b/crdppf/util/pdf_classes.py
@@ -1372,7 +1372,7 @@ class Extract(FPDF):
         self.cell(15, 6, self.translations['pagelabel'], 0, 0, 'L')
         self.cell(135, 6, self.translations['appendicestitlelabel'], 0, 1, 'L')
         
-        index =+ 1
+        index = 1
         if len(self.appendix_entries) > 0:
             for appendix in self.appendix_entries:
                 self.set_font(*self.pdfconfig.textstyles['tocbold'])

--- a/crdppf/util/pdf_classes.py
+++ b/crdppf/util/pdf_classes.py
@@ -111,9 +111,17 @@ class PDFConfig(object):
         self.siteplanbasename = config['siteplanbasename']
         self.optionaltopics = config['optionaltopics']
         try:
+            self.pilotphase  = config['pilotphase']
+        except:
+            self.pilotphase = False
+        try:
             self.disclaimer  = config['disclaimer']
         except:
-            self.disclaimer = False 
+            self.disclaimer = False
+        try:
+            self.signature  = config['signature']
+        except:
+            self.signature = False 
 
 class AppendixFile(FPDF):
     """The helper class to create the appendices files with the same corporate
@@ -446,19 +454,23 @@ class Extract(FPDF):
         self.cell(70, 5, feature_info['operator'].encode('iso-8859-1'), 0, 1, 'L')
 
         # == this note is published only as long as the legal documents are not validated
-        y= self.get_y()
-        self.set_y(y+5)
-        self.set_font(*pdfconfig.textstyles['bold'])
-        self.multi_cell(0, 5, translations['pilotphasetxt'], 0, 1, 'L')
+        # Pilot phase information block - to de/activate in config_pdf.yaml.in
+        if pdfconfig.pilotphase == True :
+            y= self.get_y()
+            self.set_y(y+5)
+            self.set_font(*pdfconfig.textstyles['bold'])
+            self.multi_cell(0, 5, translations['pilotphasetxt'], 0, 1, 'L')
         # == end of temporary info will be removed and original code :
-        # == START original code:
-#        if self.reportInfo['type'] == 'certified' or self.reportInfo['type'] == 'reducedcertified':
-#            y= self.get_y()
-#            self.set_y(y+5)
-#            self.set_font(*pdfconfig.textstyles['bold'])
-#            self.cell(0, 5, translations['signaturelabel'], 0, 0, 'L')
-        # == END original code:
 
+        # Signature block for certified extracts - to de/activate in config_pdf.yaml.in
+        if pdfconfig.signature == True :
+            if self.reportInfo['type'] == 'certified' or self.reportInfo['type'] == 'reducedcertified':
+                y= self.get_y()
+                self.set_y(y+5)
+                self.set_font(*pdfconfig.textstyles['bold'])
+                self.cell(0, 5, translations['signaturelabel']+str(' ')+self.timestamp, 0, 0, 'L')
+
+        # Disclaimer block - to de/activate in config_pdf.yaml.in
         if pdfconfig.disclaimer == True :
             self.set_y(250)
             self.set_font(*pdfconfig.textstyles['bold'])

--- a/crdppf/util/pdf_classes.py
+++ b/crdppf/util/pdf_classes.py
@@ -110,6 +110,10 @@ class PDFConfig(object):
         self.pdfbasename = config['pdfbasename']
         self.siteplanbasename = config['siteplanbasename']
         self.optionaltopics = config['optionaltopics']
+        try:
+            self.disclaimer  = config['disclaimer']
+        except:
+            self.disclaimer = False 
 
 class AppendixFile(FPDF):
     """The helper class to create the appendices files with the same corporate
@@ -454,12 +458,13 @@ class Extract(FPDF):
 #            self.set_font(*pdfconfig.textstyles['bold'])
 #            self.cell(0, 5, translations['signaturelabel'], 0, 0, 'L')
         # == END original code:
-        
-        self.set_y(250)
-        self.set_font(*pdfconfig.textstyles['bold'])
-        self.cell(0, 5, translations['disclaimerlabel'], 0, 1, 'L')
-        self.set_font(*pdfconfig.textstyles['normal'])
-        self.multi_cell(0, 5, translations['disclaimer'], 0, 1, 'L')
+
+        if pdfconfig.disclaimer == True :
+            self.set_y(250)
+            self.set_font(*pdfconfig.textstyles['bold'])
+            self.cell(0, 5, translations['disclaimerlabel'], 0, 1, 'L')
+            self.set_font(*pdfconfig.textstyles['normal'])
+            self.multi_cell(0, 5, translations['disclaimer'], 0, 1, 'L')
 
         # END TITLEPAGE
 

--- a/crdppf/util/pdf_functions.py
+++ b/crdppf/util/pdf_functions.py
@@ -94,10 +94,10 @@ def get_XML(geometry, topicid, extracttime, lang, translations):
     # data format
     format='interlis'
     xml_layers = {
-        '103':'ch.bazl.projektierungszonen-flughafenanlagen.oereb',
-        '108':'ch.bazl.sicherheitszonenplan.oereb',
-        '118':'ch.bazl.kataster-belasteter-standorte-zivilflugplaetze.oereb',
-        '119':'ch.bav.kataster-belasteter-standorte-oev.oereb'
+        'R103':'ch.bazl.projektierungszonen-flughafenanlagen.oereb',
+        'R108':'ch.bazl.sicherheitszonenplan.oereb',
+        'R118':'ch.bazl.kataster-belasteter-standorte-zivilflugplaetze.oereb',
+        'R119':'ch.bav.kataster-belasteter-standorte-oev.oereb'
         }
     
     coords = geometry.coords(DBSession)
@@ -272,19 +272,19 @@ def get_XML(geometry, topicid, extracttime, lang, translations):
                 })
 
         for geometry in geometries:
-            if topicid ==  '103':
+            if topicid in  [u'R103','103']:
                 xml_model = CHAirportProjectZonesPDF()
                 xml_model.theme = translations['CHAirportProjectZonesThemeLabel'] # u'Zones réservées des installations aéroportuaires'
                 xml_model.teneur = translations['CHAirportProjectZonesContentLabel'] # u'Limitation de la hauteur des bâtiments et autres obstacles'
-            elif topicid ==  u'108':
+            elif topicid in [u'R108','108']:
                 xml_model = CHAirportSecurityZonesPDF()
                 xml_model.theme = translations['CHAirportSecurityZonesThemeLabel'] # u'Plan de la zone de sécurité des aéroports' 
                 xml_model.teneur = translations['CHAirportSecurityZonesContentLabel'] # u'Limitation de la hauteur des bâtiments et autres obstacles'
-            elif topicid ==  u'118':
+            elif topicid in  [u'R118','118']:
                 xml_model = CHPollutedSitesCivilAirportsPDF()
                 xml_model.theme = translations['CHPollutedSitesCivilAirportsThemeLabel'] # u'Cadastre des sites pollués - domaine des transports publics'
                 xml_model.teneur = translations['CHPollutedSitesCivilAirportsContentLabel'] # u'Sites pollués' 
-            elif topicid ==  u'119':
+            elif topicid in  [u'R119','119']:
                 xml_model = CHPollutedSitesPublicTransportsPDF()
                 xml_model.theme = translations['CHPollutedSitesPublicTransportsThemeLabel'] # u'Cadastre des sites pollués - domaine des transports publics'
                 xml_model.teneur = translations['CHPollutedSitesPublicTransportsContentLabel'] # u'Sites pollués' 

--- a/crdppf/util/pdf_functions.py
+++ b/crdppf/util/pdf_functions.py
@@ -94,10 +94,10 @@ def get_XML(geometry, topicid, extracttime, lang, translations):
     # data format
     format='interlis'
     xml_layers = {
-        'R103':'ch.bazl.projektierungszonen-flughafenanlagen.oereb',
-        'R108':'ch.bazl.sicherheitszonenplan.oereb',
-        'R118':'ch.bazl.kataster-belasteter-standorte-zivilflugplaetze.oereb',
-        'R119':'ch.bav.kataster-belasteter-standorte-oev.oereb'
+        'R103': 'ch.bazl.projektierungszonen-flughafenanlagen.oereb',
+        'R108': 'ch.bazl.sicherheitszonenplan.oereb',
+        'R118': 'ch.bazl.kataster-belasteter-standorte-zivilflugplaetze.oereb',
+        'R119': 'ch.bav.kataster-belasteter-standorte-oev.oereb'
         }
     
     coords = geometry.coords(DBSession)

--- a/crdppf/views/legal_documents.py
+++ b/crdppf/views/legal_documents.py
@@ -6,7 +6,7 @@ from sqlalchemy import or_
 
 from crdppf.models import DBSession
 from crdppf.models import Topics, Town, OriginReference
-from crdppf.models import Documents, LegalDocuments, LegalBases
+from crdppf.models import Documents, LegalDocuments
 
 @view_config(route_name='getTownList', renderer='json')
 def getTownList(request):
@@ -105,56 +105,6 @@ def createNewDocEntry(request):
     DBSession.flush()
 
     return {'success':True}
-
-@view_config(route_name='getLegalbases', renderer='json')
-def getLegalbases(params):
-    """Gets all the legal bases related to a feature.
-    Input: dict with params : topic, canton, municipalitynb, cadastrenb
-    Output: legalbases
-    """
-
-    doclist = []
-    filterparams = {
-        'request': None,
-        'topic': None,
-        'layer': None,
-        'canton': None,
-        'muncipalitynb': None,
-        'cadastrenb': None
-    }
-            
-    legalbases = {}
-    
-    for param in params:
-        if params[param] is not None and param in filterparams.keys():
-            filterparams[param] = params[param]
-    
-    if param == 'topic':
-        legalbases = DBSession.query(LegalBases).filter_by(topic=params[param]).all()
-    else:
-        sdf
-        legalbases = DBSession.query(LegalBases).order_by(LegalBases.legalbaseid.asc()).all()
-
-    for legalbase in legalbases :
-        doclist.append({
-            legalbase.legalbaseid:{
-                'documentid': legalbase.legalbaseid,
-                'doctype': 'legalbase',
-                #'numcom': legalbase.numcom,
-                'topicfk': legalbase.topicfk,
-                'title': legalbase.title,
-                'officialtitle': legalbase.officialtitle,
-                'abreviation': legalbase.abreviation,
-                'officialnb': legalbase.officialnb,
-                'canton': legalbase.canton,
-                'commune': legalbase.commune,
-                'documenturl': legalbase.legalbaseurl,
-                'legalstate': legalbase.legalstate,
-                'publishedsince': legalbase.publishedsince.isoformat()
-            }
-        })
-
-    return {'legalbases': doclist}
 
 @view_config(route_name='getDocumentReferences', renderer='json')
 def getDocumentReferences(docfilters):

--- a/crdppf/views/pdf.py
+++ b/crdppf/views/pdf.py
@@ -268,7 +268,7 @@ def create_extract(request):
             appendixfile.set_link(str(j))
             appendixfile.set_font(*pdfconfig.textstyles['title3'])
             appendixfile.cell(15, 10, str('Annexe '+str(j)), 0, 1, 'L')
-            appendixfile.multi_cell(0, 10, str(appendix['title']), 0, 'L')
+            appendixfile.multi_cell(0, 10, appendix['title'], 0, 'L')
             appendixfile.output(pdfconfig.pdfpath+pdfconfig.pdfname+'_a'+str(j)+'.pdf','F')
             appendicesfiles.append(pdfconfig.pdfpath+pdfconfig.pdfname+'_a'+str(j)+'.pdf')
             extract.cleanupfiles.append(pdfconfig.pdfpath+pdfconfig.pdfname+'_a'+str(j)+'.pdf')


### PR DESCRIPTION
@kalbermattenm: Please review. I'll do some thorough testing meanwhile.
This PR fixes a lot of details regarding the way the legal documents have been filtered before.

* The functionality has been adapted and simplified based on the overhaul done in the layer tree by monodo
* All legal documents are now merged in one base table as defined by the 'Rahmenmodell' (reducing table counts)
* Removes duplicate display of legal documents
* Layout improvements
* Geralizes some more parameters into vars
* Adds some more options to the pdf configuration based on specific part PR https://github.com/sitn/crdppf/pull/230

This PR activates all available federal topics by default and requires either changes from PR https://github.com/sitn/crdppf/pull/227 merged into specific part of the application or that the topics do not have layers defined for in the layers table nor in the models.py file.

closes issues:
* https://github.com/sitn/crdppf_core/issues/47 (improvement)
* https://github.com/sitn/crdppf_core/issues/70
* https://github.com/sitn/crdppf_core/issues/48
