### PR TITLE
adding an option to call a pdf directly

### DIFF
--- a/crdppf/lib/content.py
+++ b/crdppf/lib/content.py
@@ -136,7 +136,10 @@ def get_content(id, request):
     # initalize extract object
     extract = Extract(request)
     type = request.matchdict.get("type_")
-
+    directprint = False
+    if type == 'file':
+        type = 'reduced'
+        directprint = True
     for config in configs:
         if config.parameter not in ['crdppflogopath', 'cantonlogopath']:
             extract.baseconfig[config.parameter] = config.paramvalue
@@ -525,6 +528,7 @@ def get_content(id, request):
     d = {
         "attributes": {
             "reporttype": type,
+            "directprint": directprint,
             "extractcreationdate": extract.creationdate,
             "filename": extract.filename,
             "extractid": extract.id,

--- a/crdppf/views/printproxy.py
+++ b/crdppf/views/printproxy.py
@@ -74,11 +74,18 @@ class PrintProxy(Proxy):  # pragma: no cover
         body["attributes"].update(cached_content)
         body["attributes"].update(dynamic_content["attributes"])
 
-        _string = "%s/%s/report.%s" % (
-            self.config['print_url'],
-            "crdppf",
-            "pdf"
-        )
+        if body["attributes"]['directprint'] is True:
+            _string = "%s/%s/buildreport.%s" % (
+                self.config['print_url'],
+                "crdppf",
+                "pdf"
+            )
+        else:
+            _string = "%s/%s/report.%s" % (
+                self.config['print_url'],
+                "crdppf",
+                "pdf"
+            )
 
         body = json.dumps(body)
 


### PR DESCRIPTION
this PR implements a handy little switch as asked by JU to get the PDF directly rather than the download link using the buildreport functionality instead of the report function of the mapfish print proxy 