### PR TITLE
Pdf compliance - fixes to achieve compatibility with federal specs

### DIFF
--- a/print/print-apps/crdppf/glossar.jrxml
+++ b/print/print-apps/crdppf/glossar.jrxml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.3.1.final using JasperReports Library version 6.3.1  -->
-<!-- 2017-05-11T14:06:31 -->
+<!-- Created with Jaspersoft Studio version 6.6.0.final using JasperReports Library version 6.6.0  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="report" pageWidth="595" pageHeight="842" whenNoDataType="BlankPage" columnWidth="493" leftMargin="51" rightMargin="51" topMargin="28" bottomMargin="20" uuid="9a3e59f5-6675-48cf-ad74-9c42b5a5b290">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.layout" value="com.jaspersoft.studio.editor.layout.FreeLayout"/>
@@ -100,7 +99,7 @@
 	<detail>
 		<band height="30">
 			<subreport>
-				<reportElement x="0" y="9" width="493" height="21" uuid="16848c63-ce33-4b3a-9e67-2d949e8d3c10"/>
+				<reportElement x="0" y="9" width="493" height="21" isPrintWhenDetailOverflows="true" uuid="16848c63-ce33-4b3a-9e67-2d949e8d3c10"/>
 				<dataSourceExpression><![CDATA[$F{DefinitionsTableSource}]]></dataSourceExpression>
 				<subreportExpression><![CDATA["table.jasper"]]></subreportExpression>
 			</subreport>

--- a/print/print-apps/crdppf/legalbase.jrxml
+++ b/print/print-apps/crdppf/legalbase.jrxml
@@ -18,28 +18,28 @@
 	<field name="officialnb" class="java.lang.String"/>
 	<field name="officialtitle" class="java.lang.String"/>
 	<detail>
-		<band height="30">
+		<band height="26">
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference" hyperlinkTarget="Blank">
-				<reportElement x="0" y="17" width="300" height="13" isPrintWhenDetailOverflows="true" forecolor="#4C8FBA" uuid="010fa648-c53e-4fa5-82ab-ce9a63ed9bd5">
+				<reportElement positionType="Float" x="0" y="13" width="300" height="12" isPrintWhenDetailOverflows="true" forecolor="#4C8FBA" uuid="010fa648-c53e-4fa5-82ab-ce9a63ed9bd5">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
 				<textElement verticalAlignment="Top">
 					<font fontName="Cadastra" size="6"/>
-					<paragraph leftIndent="8" spacingBefore="0" spacingAfter="2"/>
+					<paragraph leftIndent="8" spacingAfter="2"/>
 				</textElement>
 				<textFieldExpression><![CDATA[($F{remoteurl}.equals("") || $F{remoteurl} == null) ? null : $F{remoteurl}]]></textFieldExpression>
 				<hyperlinkReferenceExpression><![CDATA[($F{remoteurl}.equals("") || $F{remoteurl} == null) ? null : $F{remoteurl}]]></hyperlinkReferenceExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" bookmarkLevel="2">
-				<reportElement stretchType="RelativeToTallestObject" x="0" y="0" width="300" height="15" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" forecolor="#000000" uuid="114a9f86-a715-4eb3-a8a3-5b17bad23c1a">
+				<reportElement x="0" y="0" width="300" height="13" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" forecolor="#000000" uuid="114a9f86-a715-4eb3-a8a3-5b17bad23c1a">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
-				<textElement verticalAlignment="Middle">
+				<textElement verticalAlignment="Middle" markup="none">
 					<font fontName="Cadastra" size="8"/>
 					<paragraph lineSpacing="Single"/>
 				</textElement>
-				<textFieldExpression><![CDATA[($F{officialtitle}.equals("") || $F{officialtitle} == null ? "-" : $F{officialtitle}) + (($F{officialnb}.equals("") || $F{officialnb} == null) ? "" : ", " +$F{officialnb})]]></textFieldExpression>
+				<textFieldExpression><![CDATA[($F{officialtitle}.equals("") || $F{officialtitle} == null ? "–" : $F{officialtitle}) + (($F{officialnb}.equals("") || $F{officialnb} == null) ? "" : ", " +$F{officialnb})]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>

--- a/print/print-apps/crdppf/legalprovision.jrxml
+++ b/print/print-apps/crdppf/legalprovision.jrxml
@@ -25,15 +25,15 @@
 	<field name="officialnb" class="java.lang.String"/>
 	<field name="officialtitle" class="java.lang.String"/>
 	<detail>
-		<band height="30">
+		<band height="26">
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" hyperlinkType="Reference" hyperlinkTarget="Blank">
-				<reportElement positionType="Float" stretchType="RelativeToTallestObject" x="0" y="17" width="300" height="13" isPrintWhenDetailOverflows="true" forecolor="#4C8FBA" uuid="010fa648-c53e-4fa5-82ab-ce9a63ed9bd5">
+				<reportElement positionType="Float" x="0" y="13" width="300" height="12" isPrintWhenDetailOverflows="true" forecolor="#4C8FBA" uuid="010fa648-c53e-4fa5-82ab-ce9a63ed9bd5">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
 				<textElement verticalAlignment="Top">
 					<font fontName="Cadastra" size="6"/>
-					<paragraph leftIndent="8" spacingBefore="0" spacingAfter="2"/>
+					<paragraph leftIndent="8" spacingAfter="3"/>
 				</textElement>
 				<textFieldExpression><![CDATA[($F{remoteurl}.equals("") || $F{remoteurl} == null) ? null : $F{remoteurl}]]></textFieldExpression>
 				<hyperlinkReferenceExpression><![CDATA[($F{remoteurl}.equals("") || $F{remoteurl} == null) ? null : $F{remoteurl}]]></hyperlinkReferenceExpression>
@@ -43,14 +43,14 @@
 				<textFieldExpression><![CDATA[((ArrayList)$P{TOC_Appendices}.get($P{topicname})).add($F{officialtitle}) ? "" : ""]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true" bookmarkLevel="2">
-				<reportElement stretchType="RelativeToTallestObject" x="0" y="0" width="300" height="15" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" forecolor="#000000" uuid="114a9f86-a715-4eb3-a8a3-5b17bad23c1a">
+				<reportElement x="0" y="0" width="300" height="13" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" forecolor="#000000" uuid="114a9f86-a715-4eb3-a8a3-5b17bad23c1a">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 				</reportElement>
 				<textElement verticalAlignment="Middle">
 					<font fontName="Cadastra" size="8"/>
 					<paragraph lineSpacing="Single"/>
 				</textElement>
-				<textFieldExpression><![CDATA[($F{officialtitle}.equals("") || $F{officialtitle} == null ? "-" : $F{officialtitle}) + (($F{officialnb}.equals("") || $F{officialnb} == null) ? "" : ", " +$F{officialnb})]]></textFieldExpression>
+				<textFieldExpression><![CDATA[($F{officialtitle}.equals("") || $F{officialtitle} == null ? "–" : $F{officialtitle}) + (($F{officialnb}.equals("") || $F{officialnb} == null) ? "" : ", " +$F{officialnb})]]></textFieldExpression>
 				<hyperlinkReferenceExpression><![CDATA["http://crdppf.ne.ch"]]></hyperlinkReferenceExpression>
 			</textField>
 		</band>

--- a/print/print-apps/crdppf/legalprovision.jrxml
+++ b/print/print-apps/crdppf/legalprovision.jrxml
@@ -33,7 +33,7 @@
 				</reportElement>
 				<textElement verticalAlignment="Top">
 					<font fontName="Cadastra" size="6"/>
-					<paragraph leftIndent="8" spacingAfter="3"/>
+					<paragraph leftIndent="8" spacingAfter="2"/>
 				</textElement>
 				<textFieldExpression><![CDATA[($F{remoteurl}.equals("") || $F{remoteurl} == null) ? null : $F{remoteurl}]]></textFieldExpression>
 				<hyperlinkReferenceExpression><![CDATA[($F{remoteurl}.equals("") || $F{remoteurl} == null) ? null : $F{remoteurl}]]></hyperlinkReferenceExpression>

--- a/print/print-apps/crdppf/table.jrxml
+++ b/print/print-apps/crdppf/table.jrxml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.3.1.final using JasperReports Library version 6.3.1  -->
-<!-- 2017-05-04T10:01:01 -->
+<!-- Created with Jaspersoft Studio version 6.6.0.final using JasperReports Library version 6.6.0  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Definitions" pageWidth="493" pageHeight="842" columnWidth="493" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" whenResourceMissingType="Key" uuid="e034c6ef-7449-4a6a-9b5e-4ce04cc083b2">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
@@ -18,8 +17,8 @@
 	<detail>
 		<band height="15" splitType="Immediate">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-			<textField>
-				<reportElement x="0" y="0" width="493" height="15" uuid="bbc8f3dd-19b0-4440-aa6c-c04468e54bc2">
+			<textField isStretchWithOverflow="true">
+				<reportElement isPrintRepeatedValues="false" x="0" y="0" width="493" height="15" isPrintWhenDetailOverflows="true" uuid="bbc8f3dd-19b0-4440-aa6c-c04468e54bc2">
 					<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 				</reportElement>
@@ -30,7 +29,7 @@
 					<rightPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 				</box>
 				<textElement markup="styled">
-					<font fontName="Cadastra" size="8.5" pdfFontName="Cadastra" pdfEncoding=""/>
+					<font fontName="Cadastra" size="8" pdfFontName="Cadastra" pdfEncoding=""/>
 				</textElement>
 				<textFieldExpression><![CDATA["<b>"+$F{term}+":</b> " + $F{definition}]]></textFieldExpression>
 			</textField>


### PR DESCRIPTION
Fixes display and spacing issues in PDF for:
- [x] glossary
- [x] legal documents

sets font size to 8 and 6 px instead of 8.5 pt which do not work with Jasper templates