### PR TITLE
changed timeout from 30s to 80s for report creation

### DIFF
--- a/crdppf/static/js/Crdppf/createReport.js
+++ b/crdppf/static/js/Crdppf/createReport.js
@@ -22,6 +22,7 @@ Crdppf.Report= {
 
               },
               method: 'GET',
+              timeout: 80000,
               failure: function () {
                   Ext.Msg.alert(Crdppf.labels.serverErrorMessage);
                   pdfMask.hide();


### PR DESCRIPTION
Changed the default timeout so that the pdf creation for bigger real estates finishes