### PR TITLE
changed timeout to 100s

### DIFF
--- a/crdppf/static/js/Crdppf/createReport.js
+++ b/crdppf/static/js/Crdppf/createReport.js
@@ -22,7 +22,7 @@ Crdppf.Report= {
 
               },
               method: 'GET',
-              timeout: 80000,
+              timeout: 100000,
               failure: function () {
                   Ext.Msg.alert(Crdppf.labels.serverErrorMessage);
                   pdfMask.hide();


### PR DESCRIPTION
With latest data updates (documents, new land planning) the PDF creation has slowed down. The new timeout allows to get the PDF also for bigger properties with a lot of restrictions